### PR TITLE
Check if symlink target exists when opening image

### DIFF
--- a/geometrize/dialog/launchwindow.cpp
+++ b/geometrize/dialog/launchwindow.cpp
@@ -3,6 +3,7 @@
 
 #include <QCloseEvent>
 #include <QEvent>
+#include <QFileInfo>
 
 #include "chaiscript/chaiscript.hpp"
 
@@ -279,7 +280,8 @@ void LaunchWindow::on_actionExit_triggered()
 void LaunchWindow::on_openImageButton_clicked()
 {
     const QString imagePath{common::ui::openImagePathPickerDialog(this)};
-    if(imagePath.isEmpty()) {
+    QFileInfo imageFileInfo(imagePath);
+    if(imagePath.isEmpty() || (imageFileInfo.isSymLink() && !QFileInfo(imageFileInfo.symLinkTarget()).exists())) {
         return;
     }
 


### PR DESCRIPTION
If a symlink is opened, QFileDialog::getOpenFileName only checks if the
symlink exists, not its target.

In the case the symlink target does not exist, there is a segmentation fault (I could not pinpoint the exact line which segfaults).