### PR TITLE
geometrize.pro: Put intermediate output files into qt_gen & obj directories.

### DIFF
--- a/geometrize.pro
+++ b/geometrize.pro
@@ -2,6 +2,10 @@ QT += core gui network svg
 
 TARGET = Geometrize
 TEMPLATE = app
+OBJECTS_DIR=obj
+MOC_DIR=qt_gen
+RCC_DIR=qt_gen
+UI_DIR=qt_gen
 
 # Enable C++17 features
 CONFIG += c++17


### PR DESCRIPTION
This keeps the project root directory tidy.