### PR TITLE
[codex] Port headless orchestration to Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@
 
 # Python bytecode
 *.pyc
+__pycache__/
+
+# Python virtual environments
+.venv/
+*.egg-info/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md
+
+This file is a quick orientation guide for agents entering this repo. It should
+help you find useful work, not freeze the project into its current habits.
+
+## Project Shape
+
+- `geometrize.pro` is the qmake entrypoint for the desktop app.
+- First-party application code is under `geometrize/`.
+- The core image approximation algorithm is pulled in from the `lib/geometrize`
+  submodule and included by `lib/geometrize/geometrize/geometrize.pri`.
+- Other submodules provide scripting, serialization, GIF export, templates, web
+  export assets, and translations. Check `.gitmodules` before treating code
+  under `lib/`, `resources/templates`, `resources/web_export`, or `translations`
+  as local app ownership.
+- `resources/resources.pri` runs Python scripts from `scripts/` to generate Qt
+  resource files during qmake configuration.
+
+## First Places To Inspect
+
+- App launch and mode selection: `geometrize/main.cpp`,
+  `geometrize/cli/commandlineparser.*`.
+- Image task lifecycle and threading: `geometrize/task/imagetask.*`,
+  `geometrize/task/imagetaskworker.*`, and UI connections in
+  `geometrize/dialog/imagetaskwindow.*`.
+- Scripting surface: `geometrize/script/chaiscriptcreator.cpp` and
+  `geometrize/script/bindings/`.
+- Import/export behavior: `geometrize/image/`, `geometrize/exporter/`,
+  `geometrize/serialization/`.
+- Preferences, templates, and localization: `geometrize/preferences/`,
+  `geometrize/manifest/`, `geometrize/localization/`, `translations/`.
+
+## Build And Verification
+
+- Expected setup: Qt 5.10+ or Qt 6, Python 3, and initialized submodules.
+- Bootstrap submodules with `git submodule update --init --recursive`.
+- Typical CLI build shape, from a Qt-enabled shell:
+  `qmake C:\LocalRepos\geometrize\geometrize.pro` then `nmake` or `make`.
+- CI history lives in `.appveyor.yml` and builds Linux, macOS, and Windows MSVC
+  variants.
+- Functional self-tests exist through `--functional_tests <scripts-dir>`, but
+  coverage appears sparse. If you cannot run GUI tests locally, say so and still
+  verify targeted logic as directly as possible.
+
+## Improvement-Friendly Notes
+
+- Prefer small, behavior-focused changes in first-party app code before editing
+  submodules.
+- Be careful around `ImageTask`: it crosses Qt signals, worker threads,
+  ChaiScript state, and bitmap lifetimes.
+- When changing scripting bindings, update both engine construction and the
+  exposed ChaiScript API intentionally.
+- When touching images, exports, templates, or translations, check whether the
+  resource generation step needs to run and whether generated files are ignored.
+- There are useful cleanup candidates: CLI parsing duplication, TODOs in UI and
+  network paths, generated resource determinism, richer functional tests, and
+  clearer boundaries between GUI orchestration and task state.
+- Keep new guidance and docs short. This project already has many moving parts;
+  the next agent should be helped, not buried.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,42 @@ project(geometrize_py LANGUAGES CXX)
 
 find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
 find_package(pybind11 CONFIG REQUIRED)
+find_package(Threads REQUIRED)
 
-pybind11_add_module(_native MODULE python/geometrize_py/native_bindings.cpp)
+set(GEOMETRIZE_CORE_SOURCES
+    lib/geometrize/geometrize/geometrize/bitmap/bitmap.cpp
+    lib/geometrize/geometrize/geometrize/bitmap/rgba.cpp
+    lib/geometrize/geometrize/geometrize/rasterizer/rasterizer.cpp
+    lib/geometrize/geometrize/geometrize/rasterizer/scanline.cpp
+    lib/geometrize/geometrize/geometrize/runner/imagerunner.cpp
+    lib/geometrize/geometrize/geometrize/shape/circle.cpp
+    lib/geometrize/geometrize/geometrize/shape/ellipse.cpp
+    lib/geometrize/geometrize/geometrize/shape/line.cpp
+    lib/geometrize/geometrize/geometrize/shape/polyline.cpp
+    lib/geometrize/geometrize/geometrize/shape/quadraticbezier.cpp
+    lib/geometrize/geometrize/geometrize/shape/rectangle.cpp
+    lib/geometrize/geometrize/geometrize/shape/rotatedellipse.cpp
+    lib/geometrize/geometrize/geometrize/shape/rotatedrectangle.cpp
+    lib/geometrize/geometrize/geometrize/shape/shapefactory.cpp
+    lib/geometrize/geometrize/geometrize/shape/shapemutator.cpp
+    lib/geometrize/geometrize/geometrize/shape/shapetypes.cpp
+    lib/geometrize/geometrize/geometrize/shape/triangle.cpp
+    lib/geometrize/geometrize/geometrize/commonutil.cpp
+    lib/geometrize/geometrize/geometrize/core.cpp
+    lib/geometrize/geometrize/geometrize/model.cpp
+    lib/geometrize/geometrize/geometrize/state.cpp
+)
+
+pybind11_add_module(_native MODULE
+    python/geometrize_py/native_bindings.cpp
+    ${GEOMETRIZE_CORE_SOURCES}
+)
+target_include_directories(_native PRIVATE lib/geometrize/geometrize)
 target_compile_features(_native PRIVATE cxx_std_17)
+target_link_libraries(_native PRIVATE Threads::Threads)
+
+if(MSVC)
+    target_compile_options(_native PRIVATE /bigobj)
+endif()
 
 install(TARGETS _native DESTINATION geometrize_py)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(geometrize_py LANGUAGES CXX)
+
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+find_package(pybind11 CONFIG REQUIRED)
+
+pybind11_add_module(_native MODULE python/geometrize_py/native_bindings.cpp)
+target_compile_features(_native PRIVATE cxx_std_17)
+
+install(TARGETS _native DESTINATION geometrize_py)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
-requires = ["scikit-build-core>=0.12", "pybind11>=3"]
+requires = [
+    "scikit-build-core>=0.12",
+    "pybind11>=3",
+    "cmake>=3.20",
+    "ninja",
+]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "geometrize-py"
+version = "0.1.0"
+description = "Python headless orchestration layer for Geometrize."
+requires-python = ">=3.10"
+
+[project.scripts]
+geometrize-py = "geometrize_py.cli:entrypoint"
+
+[tool.setuptools]
+package-dir = {"" = "python"}
+
+[tool.setuptools.packages.find]
+where = ["python"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=69"]
-build-backend = "setuptools.build_meta"
+requires = ["scikit-build-core>=0.12", "pybind11>=3"]
+build-backend = "scikit_build_core.build"
 
 [project]
 name = "geometrize-py"
@@ -12,8 +12,5 @@ dependencies = ["Pillow>=10"]
 [project.scripts]
 geometrize-py = "geometrize_py.cli:entrypoint"
 
-[tool.setuptools]
-package-dir = {"" = "python"}
-
-[tool.setuptools.packages.find]
-where = ["python"]
+[tool.scikit-build]
+wheel.packages = ["python/geometrize_py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "geometrize-py"
 version = "0.1.0"
 description = "Python headless orchestration layer for Geometrize."
 requires-python = ">=3.10"
+dependencies = ["Pillow>=10"]
 
 [project.scripts]
 geometrize-py = "geometrize_py.cli:entrypoint"

--- a/python/README.md
+++ b/python/README.md
@@ -7,6 +7,13 @@ This package is intentionally thin at first. It owns CLI parsing, job
 configuration, screenshot discovery, and the boundary where a native runner will
 plug in later.
 
+Install the package into the repo-local venv:
+
+```powershell
+python -m venv C:\LocalRepos\geometrize\.venv
+C:\LocalRepos\geometrize\.venv\Scripts\python.exe -m pip install -e C:\LocalRepos\geometrize
+```
+
 Run the current test suite:
 
 ```powershell

--- a/python/README.md
+++ b/python/README.md
@@ -25,3 +25,9 @@ Preview a 4000-triangle job without invoking the native core:
 ```powershell
 C:\LocalRepos\geometrize\.venv\Scripts\geometrize-py.exe run --latest-screenshot --output C:\LocalRepos\geometrize\outputs\screenshot_4000_triangles.png --shape triangle --count 4000 --dry-run
 ```
+
+Run from a JSON job manifest:
+
+```powershell
+C:\LocalRepos\geometrize\.venv\Scripts\geometrize-py.exe run --job C:\LocalRepos\geometrize\job.json --dry-run
+```

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,20 @@
+# Geometrize Python Port
+
+Goal: move the headless and app-orchestration layers toward Python while
+keeping the existing C++ image approximation algorithm as the native core.
+
+This package is intentionally thin at first. It owns CLI parsing, job
+configuration, screenshot discovery, and the boundary where a native runner will
+plug in later.
+
+Run the current test suite:
+
+```powershell
+C:\LocalRepos\geometrize\.venv\Scripts\python.exe -m unittest discover -s C:\LocalRepos\geometrize\tests\python
+```
+
+Preview a 4000-triangle job without invoking the native core:
+
+```powershell
+C:\LocalRepos\geometrize\.venv\Scripts\geometrize-py.exe run --latest-screenshot --output C:\LocalRepos\geometrize\outputs\screenshot_4000_triangles.png --shape triangle --count 4000 --dry-run
+```

--- a/python/README.md
+++ b/python/README.md
@@ -41,8 +41,44 @@ Write reusable shape data instead of a PNG:
 C:\LocalRepos\geometrize\.venv\Scripts\geometrize-py.exe run --latest-screenshot --output C:\LocalRepos\geometrize\outputs\screenshot_4000_triangles.json --shape triangle --count 4000 --export-format json
 ```
 
+Write SVG:
+
+```powershell
+C:\LocalRepos\geometrize\.venv\Scripts\geometrize-py.exe run --latest-screenshot --output C:\LocalRepos\geometrize\outputs\screenshot_4000_triangles.svg --shape triangle --count 4000 --export-format svg
+```
+
 Run from a JSON job manifest:
 
 ```powershell
 C:\LocalRepos\geometrize\.venv\Scripts\geometrize-py.exe run --job C:\LocalRepos\geometrize\job.json --dry-run
+```
+
+Run a batch manifest:
+
+```powershell
+C:\LocalRepos\geometrize\.venv\Scripts\geometrize-py.exe batch --manifest C:\LocalRepos\geometrize\batch.json
+```
+
+Batch manifests use version `1`, optional shared defaults, and a `jobs` list:
+
+```json
+{
+  "version": 1,
+  "defaults": {
+    "shape": "triangle",
+    "count": 4000,
+    "export_format": "png"
+  },
+  "jobs": [
+    {
+      "input_path": "C:/images/a.png",
+      "output_path": "C:/out/a.png"
+    },
+    {
+      "input_path": "C:/images/b.png",
+      "output_path": "C:/out/b.svg",
+      "export_format": "svg"
+    }
+  ]
+}
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -3,9 +3,9 @@
 Goal: move the headless and app-orchestration layers toward Python while
 keeping the existing C++ image approximation algorithm as the native core.
 
-This package is intentionally thin at first. It owns CLI parsing, job
-configuration, screenshot discovery, and the boundary where a native runner will
-plug in later.
+This package owns CLI parsing, job configuration, screenshot discovery, Python
+image IO, and a small pybind11 bridge to the native `lib/geometrize`
+`ImageRunner`. It does not port the shape-fitting algorithm itself.
 
 Install the package into the repo-local venv:
 
@@ -13,6 +13,9 @@ Install the package into the repo-local venv:
 python -m venv C:\LocalRepos\geometrize\.venv
 C:\LocalRepos\geometrize\.venv\Scripts\python.exe -m pip install -e C:\LocalRepos\geometrize
 ```
+
+The editable install builds the native extension with `scikit-build-core`,
+`pybind11`, CMake, and the local C++ compiler.
 
 Run the current test suite:
 
@@ -24,6 +27,18 @@ Preview a 4000-triangle job without invoking the native core:
 
 ```powershell
 C:\LocalRepos\geometrize\.venv\Scripts\geometrize-py.exe run --latest-screenshot --output C:\LocalRepos\geometrize\outputs\screenshot_4000_triangles.png --shape triangle --count 4000 --dry-run
+```
+
+Run a real native-core job:
+
+```powershell
+C:\LocalRepos\geometrize\.venv\Scripts\geometrize-py.exe run --latest-screenshot --output C:\LocalRepos\geometrize\outputs\screenshot_4000_triangles.png --shape triangle --count 4000
+```
+
+Write reusable shape data instead of a PNG:
+
+```powershell
+C:\LocalRepos\geometrize\.venv\Scripts\geometrize-py.exe run --latest-screenshot --output C:\LocalRepos\geometrize\outputs\screenshot_4000_triangles.json --shape triangle --count 4000 --export-format json
 ```
 
 Run from a JSON job manifest:

--- a/python/geometrize_py/__init__.py
+++ b/python/geometrize_py/__init__.py
@@ -1,0 +1,5 @@
+"""Python orchestration layer for Geometrize."""
+
+from geometrize_py.jobs import ExportFormat, GeometrizeJob, ShapeType
+
+__all__ = ["ExportFormat", "GeometrizeJob", "ShapeType"]

--- a/python/geometrize_py/__main__.py
+++ b/python/geometrize_py/__main__.py
@@ -1,0 +1,5 @@
+from geometrize_py.cli import entrypoint
+
+
+if __name__ == "__main__":
+    entrypoint()

--- a/python/geometrize_py/batch.py
+++ b/python/geometrize_py/batch.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from geometrize_py.jobs import ExportFormat, GeometrizeJob, ShapeType, derive_output_path
+
+
+@dataclass(frozen=True, slots=True)
+class BatchManifest:
+    path: Path
+    jobs: list[GeometrizeJob]
+
+
+def load_batch_manifest(path: Path) -> BatchManifest:
+    path = Path(path)
+    data = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(data, dict):
+        raise ValueError("batch manifest must contain a JSON object")
+
+    if int(data.get("version", 1)) != 1:
+        raise ValueError("unsupported batch manifest version")
+
+    defaults = data.get("defaults", {})
+    if not isinstance(defaults, dict):
+        raise ValueError("batch manifest defaults must be a JSON object")
+
+    jobs_data = data.get("jobs")
+    if not isinstance(jobs_data, list) or not jobs_data:
+        raise ValueError("batch manifest jobs must be a non-empty list")
+
+    base_dir = path.parent
+    jobs: list[GeometrizeJob] = []
+    for index, job_data in enumerate(jobs_data):
+        if not isinstance(job_data, dict):
+            raise ValueError(f"batch manifest job {index} must be a JSON object")
+        merged = {**defaults, **job_data}
+        jobs.append(_job_from_mapping(merged, base_dir, index))
+
+    return BatchManifest(path=path, jobs=jobs)
+
+
+def _job_from_mapping(data: dict[str, Any], base_dir: Path, index: int) -> GeometrizeJob:
+    if "input_path" not in data:
+        raise ValueError(f"batch manifest job {index} is missing required field: input_path")
+
+    shape = ShapeType.from_cli(str(data.get("shape", ShapeType.ELLIPSE.value)))
+    count = int(data["count"]) if "count" in data else None
+    if count is None:
+        raise ValueError(f"batch manifest job {index} is missing required field: count")
+
+    export_format = ExportFormat.from_cli(str(data.get("export_format", ExportFormat.PNG.value)))
+    input_path = _resolve_manifest_path(base_dir, data["input_path"])
+    output_path = (
+        _resolve_manifest_path(base_dir, data["output_path"])
+        if "output_path" in data
+        else derive_output_path(input_path, shape, count, export_format)
+    )
+
+    return GeometrizeJob(
+        input_path=input_path,
+        output_path=output_path,
+        shape=shape,
+        count=count,
+        export_format=export_format,
+        alpha=int(data.get("alpha", 128)),
+        candidate_shape_count=int(data.get("candidate_shape_count", 50)),
+        max_shape_mutations=int(data.get("max_shape_mutations", 100)),
+        seed=int(data.get("seed", 9001)),
+        max_threads=int(data.get("max_threads", 0)),
+    )
+
+
+def _resolve_manifest_path(base_dir: Path, value: Any) -> Path:
+    path = Path(str(value))
+    if path.is_absolute():
+        return path
+    return base_dir / path

--- a/python/geometrize_py/cli.py
+++ b/python/geometrize_py/cli.py
@@ -8,6 +8,7 @@ from typing import Sequence
 
 from geometrize_py.images import inspect_image
 from geometrize_py.jobs import ExportFormat, GeometrizeJob, ShapeType, derive_output_path
+from geometrize_py.manifests import load_job
 from geometrize_py.native import NativeCoreUnavailable, NativeRunner
 from geometrize_py.screenshots import find_latest_screenshot
 
@@ -43,9 +44,10 @@ def build_parser() -> argparse.ArgumentParser:
     source = run.add_mutually_exclusive_group(required=True)
     source.add_argument("--input", type=Path, help="Image path to geometrize.")
     source.add_argument("--latest-screenshot", action="store_true", help="Use the newest screenshot image.")
+    source.add_argument("--job", type=Path, help="JSON job manifest to run.")
     run.add_argument("--output", type=Path, help="Output path. Defaults beside the input image.")
     run.add_argument("--shape", default="ellipse", choices=ShapeType.cli_choices())
-    run.add_argument("--count", type=int, required=True, help="Number of accepted shapes to request.")
+    run.add_argument("--count", type=int, help="Number of accepted shapes to request.")
     run.add_argument("--export-format", default="png", choices=[format_.value for format_ in ExportFormat])
     run.add_argument("--alpha", type=int, default=128)
     run.add_argument("--candidate-shape-count", type=int, default=50)
@@ -62,26 +64,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _run(args: argparse.Namespace) -> int:
-    input_path = _resolve_input_path(args)
-    if not input_path.exists():
-        print(f"error: input image does not exist: {input_path}", file=sys.stderr)
+    job = _resolve_job(args)
+    if not job.input_path.exists():
+        print(f"error: input image does not exist: {job.input_path}", file=sys.stderr)
         return 2
-
-    shape = ShapeType.from_cli(args.shape)
-    export_format = ExportFormat.from_cli(args.export_format)
-    output_path = args.output or derive_output_path(input_path, shape, args.count, export_format)
-    job = GeometrizeJob(
-        input_path=input_path,
-        output_path=output_path,
-        shape=shape,
-        count=args.count,
-        export_format=export_format,
-        alpha=args.alpha,
-        candidate_shape_count=args.candidate_shape_count,
-        max_shape_mutations=args.max_shape_mutations,
-        seed=args.seed,
-        max_threads=args.max_threads,
-    )
 
     if args.dry_run:
         print(json.dumps(job.as_plan(runner="dry-run"), indent=2, sort_keys=True))
@@ -119,3 +105,27 @@ def _resolve_input_path(args: argparse.Namespace) -> Path:
             raise ValueError("no screenshot image found")
         return screenshot
     return args.input
+
+
+def _resolve_job(args: argparse.Namespace) -> GeometrizeJob:
+    if args.job:
+        return load_job(args.job)
+    if args.count is None:
+        raise ValueError("--count is required unless --job is supplied")
+
+    input_path = _resolve_input_path(args)
+    shape = ShapeType.from_cli(args.shape)
+    export_format = ExportFormat.from_cli(args.export_format)
+    output_path = args.output or derive_output_path(input_path, shape, args.count, export_format)
+    return GeometrizeJob(
+        input_path=input_path,
+        output_path=output_path,
+        shape=shape,
+        count=args.count,
+        export_format=export_format,
+        alpha=args.alpha,
+        candidate_shape_count=args.candidate_shape_count,
+        max_shape_mutations=args.max_shape_mutations,
+        seed=args.seed,
+        max_threads=args.max_threads,
+    )

--- a/python/geometrize_py/cli.py
+++ b/python/geometrize_py/cli.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 from typing import Sequence
 
+from geometrize_py.batch import load_batch_manifest
 from geometrize_py.images import inspect_image
 from geometrize_py.jobs import ExportFormat, GeometrizeJob, ShapeType, derive_output_path
 from geometrize_py.manifests import load_job
@@ -24,6 +25,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             return _latest_screenshot()
         if args.command == "inspect":
             return _inspect(args)
+        if args.command == "batch":
+            return _batch(args)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -60,6 +63,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     inspect = subparsers.add_parser("inspect", help="Print image metadata as JSON.")
     inspect.add_argument("input", type=Path, help="Image path to inspect.")
+
+    batch = subparsers.add_parser("batch", help="Run or preview a batch manifest.")
+    batch.add_argument("--manifest", type=Path, required=True, help="Batch JSON manifest.")
+    batch.add_argument("--dry-run", action="store_true", help="Print resolved job plans without invoking native code.")
+    batch.add_argument("--continue-on-error", action="store_true", help="Keep running after individual job failures.")
     return parser
 
 
@@ -96,6 +104,57 @@ def _inspect(args: argparse.Namespace) -> int:
     info = inspect_image(args.input)
     print(json.dumps(info.as_dict(), indent=2, sort_keys=True))
     return 0
+
+
+def _batch(args: argparse.Namespace) -> int:
+    manifest = load_batch_manifest(args.manifest)
+    if args.dry_run:
+        print(
+            json.dumps(
+                {
+                    "jobs_total": len(manifest.jobs),
+                    "plans": [job.as_plan(runner="dry-run") for job in manifest.jobs],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    summary: dict[str, object] = {
+        "jobs_total": len(manifest.jobs),
+        "jobs_succeeded": 0,
+        "jobs_failed": 0,
+        "results": [],
+    }
+    results: list[dict[str, object]] = []
+    runner = NativeRunner()
+
+    for index, job in enumerate(manifest.jobs):
+        try:
+            if not job.input_path.exists():
+                raise ValueError(f"input image does not exist: {job.input_path}")
+            result = runner.run(job)
+            results.append(
+                {
+                    "index": index,
+                    "output_path": str(result.output_path),
+                    "shapes_written": result.shapes_written,
+                    "attempts": result.attempts,
+                }
+            )
+            summary["jobs_succeeded"] = int(summary["jobs_succeeded"]) + 1
+        except (NativeCoreUnavailable, ValueError) as exc:
+            results.append({"index": index, "error": str(exc), "output_path": str(job.output_path)})
+            summary["jobs_failed"] = int(summary["jobs_failed"]) + 1
+            if not args.continue_on_error:
+                summary["results"] = results
+                print(json.dumps(summary, indent=2, sort_keys=True))
+                return 2
+
+    summary["results"] = results
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 1 if int(summary["jobs_failed"]) else 0
 
 
 def _resolve_input_path(args: argparse.Namespace) -> Path:

--- a/python/geometrize_py/cli.py
+++ b/python/geometrize_py/cli.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from geometrize_py.jobs import ExportFormat, GeometrizeJob, ShapeType, derive_output_path
+from geometrize_py.native import NativeCoreUnavailable, NativeRunner
+from geometrize_py.screenshots import find_latest_screenshot
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "run":
+            return _run(args)
+        if args.command == "latest-screenshot":
+            return _latest_screenshot()
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    parser.print_help(sys.stderr)
+    return 2
+
+
+def entrypoint() -> None:
+    raise SystemExit(main())
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="geometrize-py")
+    subparsers = parser.add_subparsers(dest="command")
+
+    run = subparsers.add_parser("run", help="Run or preview a headless geometrize job.")
+    source = run.add_mutually_exclusive_group(required=True)
+    source.add_argument("--input", type=Path, help="Image path to geometrize.")
+    source.add_argument("--latest-screenshot", action="store_true", help="Use the newest screenshot image.")
+    run.add_argument("--output", type=Path, help="Output path. Defaults beside the input image.")
+    run.add_argument("--shape", default="ellipse", choices=ShapeType.cli_choices())
+    run.add_argument("--count", type=int, required=True, help="Number of accepted shapes to request.")
+    run.add_argument("--export-format", default="png", choices=[format_.value for format_ in ExportFormat])
+    run.add_argument("--alpha", type=int, default=128)
+    run.add_argument("--candidate-shape-count", type=int, default=50)
+    run.add_argument("--max-shape-mutations", type=int, default=100)
+    run.add_argument("--seed", type=int, default=9001)
+    run.add_argument("--max-threads", type=int, default=0)
+    run.add_argument("--dry-run", action="store_true", help="Print the job plan without invoking native code.")
+
+    subparsers.add_parser("latest-screenshot", help="Print the newest screenshot path.")
+    return parser
+
+
+def _run(args: argparse.Namespace) -> int:
+    input_path = _resolve_input_path(args)
+    if not input_path.exists():
+        print(f"error: input image does not exist: {input_path}", file=sys.stderr)
+        return 2
+
+    shape = ShapeType.from_cli(args.shape)
+    export_format = ExportFormat.from_cli(args.export_format)
+    output_path = args.output or derive_output_path(input_path, shape, args.count, export_format)
+    job = GeometrizeJob(
+        input_path=input_path,
+        output_path=output_path,
+        shape=shape,
+        count=args.count,
+        export_format=export_format,
+        alpha=args.alpha,
+        candidate_shape_count=args.candidate_shape_count,
+        max_shape_mutations=args.max_shape_mutations,
+        seed=args.seed,
+        max_threads=args.max_threads,
+    )
+
+    if args.dry_run:
+        print(json.dumps(job.as_plan(runner="dry-run"), indent=2, sort_keys=True))
+        return 0
+
+    try:
+        result = NativeRunner().run(job)
+    except NativeCoreUnavailable as exc:
+        print(f"error: native core unavailable: {exc}", file=sys.stderr)
+        return 2
+
+    print(json.dumps({"output_path": str(result.output_path), "shapes_written": result.shapes_written}))
+    return 0
+
+
+def _latest_screenshot() -> int:
+    screenshot = find_latest_screenshot()
+    if screenshot is None:
+        print("error: no screenshot image found", file=sys.stderr)
+        return 2
+    print(screenshot)
+    return 0
+
+
+def _resolve_input_path(args: argparse.Namespace) -> Path:
+    if args.latest_screenshot:
+        screenshot = find_latest_screenshot()
+        if screenshot is None:
+            raise ValueError("no screenshot image found")
+        return screenshot
+    return args.input

--- a/python/geometrize_py/cli.py
+++ b/python/geometrize_py/cli.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 from typing import Sequence
 
+from geometrize_py.images import inspect_image
 from geometrize_py.jobs import ExportFormat, GeometrizeJob, ShapeType, derive_output_path
 from geometrize_py.native import NativeCoreUnavailable, NativeRunner
 from geometrize_py.screenshots import find_latest_screenshot
@@ -20,6 +21,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             return _run(args)
         if args.command == "latest-screenshot":
             return _latest_screenshot()
+        if args.command == "inspect":
+            return _inspect(args)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -52,6 +55,9 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--dry-run", action="store_true", help="Print the job plan without invoking native code.")
 
     subparsers.add_parser("latest-screenshot", help="Print the newest screenshot path.")
+
+    inspect = subparsers.add_parser("inspect", help="Print image metadata as JSON.")
+    inspect.add_argument("input", type=Path, help="Image path to inspect.")
     return parser
 
 
@@ -97,6 +103,12 @@ def _latest_screenshot() -> int:
         print("error: no screenshot image found", file=sys.stderr)
         return 2
     print(screenshot)
+    return 0
+
+
+def _inspect(args: argparse.Namespace) -> int:
+    info = inspect_image(args.input)
+    print(json.dumps(info.as_dict(), indent=2, sort_keys=True))
     return 0
 
 

--- a/python/geometrize_py/images.py
+++ b/python/geometrize_py/images.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from PIL import Image
+
+
+@dataclass(frozen=True, slots=True)
+class ImageInfo:
+    path: Path
+    width: int
+    height: int
+    mode: str
+    format: str | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "path": str(self.path),
+            "width": self.width,
+            "height": self.height,
+            "mode": self.mode,
+            "format": self.format,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RgbaImage:
+    width: int
+    height: int
+    rgba: bytes
+
+    def __post_init__(self) -> None:
+        if self.width <= 0:
+            raise ValueError("width must be greater than zero")
+        if self.height <= 0:
+            raise ValueError("height must be greater than zero")
+        expected_length = self.width * self.height * 4
+        if len(self.rgba) != expected_length:
+            raise ValueError(f"rgba data must contain {expected_length} bytes")
+
+
+def inspect_image(path: Path) -> ImageInfo:
+    path = Path(path)
+    with Image.open(path) as image:
+        return ImageInfo(
+            path=path,
+            width=image.width,
+            height=image.height,
+            mode=image.mode,
+            format=image.format,
+        )
+
+
+def load_rgba_image(path: Path) -> RgbaImage:
+    path = Path(path)
+    with Image.open(path) as image:
+        rgba = image.convert("RGBA")
+        return RgbaImage(width=rgba.width, height=rgba.height, rgba=rgba.tobytes())
+
+
+def save_rgba_image(image: RgbaImage, path: Path) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pil_image = Image.frombytes("RGBA", (image.width, image.height), image.rgba)
+    pil_image.save(path)

--- a/python/geometrize_py/jobs.py
+++ b/python/geometrize_py/jobs.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class ShapeType(Enum):
+    RECTANGLE = "rectangle"
+    ROTATED_RECTANGLE = "rotated_rectangle"
+    TRIANGLE = "triangle"
+    ELLIPSE = "ellipse"
+    ROTATED_ELLIPSE = "rotated_ellipse"
+    CIRCLE = "circle"
+    LINE = "line"
+    QUADRATIC_BEZIER = "quadratic_bezier"
+    POLYLINE = "polyline"
+
+    @classmethod
+    def from_cli(cls, value: str) -> "ShapeType":
+        normalized = value.strip().lower().replace("-", "_")
+        for shape in cls:
+            if shape.value == normalized:
+                return shape
+        choices = ", ".join(shape.cli_name for shape in cls)
+        raise ValueError(f"unknown shape {value!r}; expected one of: {choices}")
+
+    @property
+    def cli_name(self) -> str:
+        return self.value.replace("_", "-")
+
+    @classmethod
+    def cli_choices(cls) -> list[str]:
+        choices: list[str] = []
+        for shape in cls:
+            choices.append(shape.cli_name)
+            if shape.cli_name != shape.value:
+                choices.append(shape.value)
+        return choices
+
+
+class ExportFormat(Enum):
+    PNG = "png"
+    SVG = "svg"
+    JSON = "json"
+
+    @classmethod
+    def from_cli(cls, value: str) -> "ExportFormat":
+        normalized = value.strip().lower().lstrip(".")
+        for export_format in cls:
+            if export_format.value == normalized:
+                return export_format
+        choices = ", ".join(format_.value for format_ in cls)
+        raise ValueError(f"unknown export format {value!r}; expected one of: {choices}")
+
+
+@dataclass(slots=True)
+class GeometrizeJob:
+    input_path: Path
+    output_path: Path
+    shape: ShapeType
+    count: int
+    export_format: ExportFormat = ExportFormat.PNG
+    alpha: int = 128
+    candidate_shape_count: int = 50
+    max_shape_mutations: int = 100
+    seed: int = 9001
+    max_threads: int = 0
+
+    def __post_init__(self) -> None:
+        self.input_path = Path(self.input_path)
+        self.output_path = Path(self.output_path)
+        self.shape = self.shape if isinstance(self.shape, ShapeType) else ShapeType.from_cli(str(self.shape))
+        self.export_format = (
+            self.export_format
+            if isinstance(self.export_format, ExportFormat)
+            else ExportFormat.from_cli(str(self.export_format))
+        )
+        self._validate_positive("count", self.count)
+        self._validate_alpha()
+        self._validate_positive("candidate_shape_count", self.candidate_shape_count)
+        self._validate_positive("max_shape_mutations", self.max_shape_mutations)
+        self._validate_non_negative("seed", self.seed)
+        self._validate_non_negative("max_threads", self.max_threads)
+
+    def as_plan(self, runner: str) -> dict[str, Any]:
+        return {
+            "input_path": str(self.input_path),
+            "output_path": str(self.output_path),
+            "shape": self.shape.cli_name,
+            "count": self.count,
+            "export_format": self.export_format.value,
+            "alpha": self.alpha,
+            "candidate_shape_count": self.candidate_shape_count,
+            "max_shape_mutations": self.max_shape_mutations,
+            "seed": self.seed,
+            "max_threads": self.max_threads,
+            "runner": runner,
+        }
+
+    def _validate_alpha(self) -> None:
+        if not 0 <= self.alpha <= 255:
+            raise ValueError("alpha must be between 0 and 255")
+
+    @staticmethod
+    def _validate_positive(name: str, value: int) -> None:
+        if value <= 0:
+            raise ValueError(f"{name} must be greater than zero")
+
+    @staticmethod
+    def _validate_non_negative(name: str, value: int) -> None:
+        if value < 0:
+            raise ValueError(f"{name} must be greater than or equal to zero")
+
+
+def derive_output_path(input_path: Path, shape: ShapeType, count: int, export_format: ExportFormat) -> Path:
+    input_path = Path(input_path)
+    suffix = f"_geometrized_{count}_{shape.cli_name.replace('-', '_')}.{export_format.value}"
+    return input_path.with_name(input_path.stem + suffix)

--- a/python/geometrize_py/manifests.py
+++ b/python/geometrize_py/manifests.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from geometrize_py.jobs import ExportFormat, GeometrizeJob, ShapeType
+
+
+REQUIRED_JOB_FIELDS = ("input_path", "output_path", "shape", "count")
+
+
+def load_job(path: Path) -> GeometrizeJob:
+    path = Path(path)
+    data = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(data, dict):
+        raise ValueError("job manifest must contain a JSON object")
+
+    for field in REQUIRED_JOB_FIELDS:
+        if field not in data:
+            raise ValueError(f"job manifest is missing required field: {field}")
+
+    return GeometrizeJob(
+        input_path=Path(str(data["input_path"])),
+        output_path=Path(str(data["output_path"])),
+        shape=ShapeType.from_cli(str(data["shape"])),
+        count=int(data["count"]),
+        export_format=ExportFormat.from_cli(str(data.get("export_format", ExportFormat.PNG.value))),
+        alpha=int(data.get("alpha", 128)),
+        candidate_shape_count=int(data.get("candidate_shape_count", 50)),
+        max_shape_mutations=int(data.get("max_shape_mutations", 100)),
+        seed=int(data.get("seed", 9001)),
+        max_threads=int(data.get("max_threads", 0)),
+    )
+
+
+def save_job(job: GeometrizeJob, path: Path) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(job_to_dict(job), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def job_to_dict(job: GeometrizeJob) -> dict[str, Any]:
+    return {
+        "input_path": str(job.input_path),
+        "output_path": str(job.output_path),
+        "shape": job.shape.cli_name,
+        "count": job.count,
+        "export_format": job.export_format.value,
+        "alpha": job.alpha,
+        "candidate_shape_count": job.candidate_shape_count,
+        "max_shape_mutations": job.max_shape_mutations,
+        "seed": job.seed,
+        "max_threads": job.max_threads,
+    }

--- a/python/geometrize_py/native.py
+++ b/python/geometrize_py/native.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from geometrize_py.jobs import GeometrizeJob
+from geometrize_py.images import RgbaImage, load_rgba_image, save_rgba_image
+from geometrize_py.jobs import ExportFormat, GeometrizeJob
 
 
 class NativeCoreUnavailable(RuntimeError):
@@ -22,10 +23,45 @@ def is_native_core_available() -> bool:
 class RunResult:
     output_path: Path
     shapes_written: int
+    attempts: int
 
 
 class NativeRunner:
     def run(self, job: GeometrizeJob) -> RunResult:
-        raise NativeCoreUnavailable(
-            "The Python CLI is ready, but the native core binding is not available yet."
+        try:
+            from geometrize_py import _native
+        except ImportError as exc:
+            raise NativeCoreUnavailable(
+                "The Python CLI is ready, but the native core binding is not available yet."
+            ) from exc
+
+        if job.export_format is not ExportFormat.PNG:
+            raise ValueError(f"native runner currently supports PNG output, not {job.export_format.value}")
+
+        input_image = load_rgba_image(job.input_path)
+        result = _native.run_rgba(
+            input_image.width,
+            input_image.height,
+            input_image.rgba,
+            {
+                "shape": job.shape.cli_name,
+                "count": job.count,
+                "alpha": job.alpha,
+                "candidate_shape_count": job.candidate_shape_count,
+                "max_shape_mutations": job.max_shape_mutations,
+                "seed": job.seed,
+                "max_threads": job.max_threads,
+            },
+        )
+
+        output_image = RgbaImage(
+            width=int(result["width"]),
+            height=int(result["height"]),
+            rgba=bytes(result["rgba"]),
+        )
+        save_rgba_image(output_image, job.output_path)
+        return RunResult(
+            output_path=job.output_path,
+            shapes_written=len(result["shapes"]),
+            attempts=int(result["attempts"]),
         )

--- a/python/geometrize_py/native.py
+++ b/python/geometrize_py/native.py
@@ -10,6 +10,14 @@ class NativeCoreUnavailable(RuntimeError):
     """Raised when the C++ Geometrize core has not been bound yet."""
 
 
+def is_native_core_available() -> bool:
+    try:
+        import geometrize_py._native  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 @dataclass(frozen=True, slots=True)
 class RunResult:
     output_path: Path

--- a/python/geometrize_py/native.py
+++ b/python/geometrize_py/native.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from geometrize_py.jobs import GeometrizeJob
+
+
+class NativeCoreUnavailable(RuntimeError):
+    """Raised when the C++ Geometrize core has not been bound yet."""
+
+
+@dataclass(frozen=True, slots=True)
+class RunResult:
+    output_path: Path
+    shapes_written: int
+
+
+class NativeRunner:
+    def run(self, job: GeometrizeJob) -> RunResult:
+        raise NativeCoreUnavailable(
+            "The Python CLI is ready, but the native core binding is not available yet."
+        )

--- a/python/geometrize_py/native.py
+++ b/python/geometrize_py/native.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -35,9 +36,6 @@ class NativeRunner:
                 "The Python CLI is ready, but the native core binding is not available yet."
             ) from exc
 
-        if job.export_format is not ExportFormat.PNG:
-            raise ValueError(f"native runner currently supports PNG output, not {job.export_format.value}")
-
         input_image = load_rgba_image(job.input_path)
         result = _native.run_rgba(
             input_image.width,
@@ -54,14 +52,31 @@ class NativeRunner:
             },
         )
 
-        output_image = RgbaImage(
-            width=int(result["width"]),
-            height=int(result["height"]),
-            rgba=bytes(result["rgba"]),
-        )
-        save_rgba_image(output_image, job.output_path)
+        if job.export_format is ExportFormat.PNG:
+            output_image = RgbaImage(
+                width=int(result["width"]),
+                height=int(result["height"]),
+                rgba=bytes(result["rgba"]),
+            )
+            save_rgba_image(output_image, job.output_path)
+        elif job.export_format is ExportFormat.JSON:
+            self._save_json_result(result, job.output_path)
+        else:
+            raise ValueError(f"native runner currently supports PNG and JSON output, not {job.export_format.value}")
+
         return RunResult(
             output_path=job.output_path,
             shapes_written=len(result["shapes"]),
             attempts=int(result["attempts"]),
         )
+
+    @staticmethod
+    def _save_json_result(result: dict, output_path: Path) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "width": int(result["width"]),
+            "height": int(result["height"]),
+            "attempts": int(result["attempts"]),
+            "shapes": list(result["shapes"]),
+        }
+        output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/python/geometrize_py/native.py
+++ b/python/geometrize_py/native.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from geometrize_py.images import RgbaImage, load_rgba_image, save_rgba_image
 from geometrize_py.jobs import ExportFormat, GeometrizeJob
+from geometrize_py.svg import save_svg
 
 
 class NativeCoreUnavailable(RuntimeError):
@@ -61,8 +62,10 @@ class NativeRunner:
             save_rgba_image(output_image, job.output_path)
         elif job.export_format is ExportFormat.JSON:
             self._save_json_result(result, job.output_path)
+        elif job.export_format is ExportFormat.SVG:
+            save_svg(int(result["width"]), int(result["height"]), result["shapes"], job.output_path)
         else:
-            raise ValueError(f"native runner currently supports PNG and JSON output, not {job.export_format.value}")
+            raise ValueError(f"native runner currently supports PNG, SVG, and JSON output, not {job.export_format.value}")
 
         return RunResult(
             output_path=job.output_path,

--- a/python/geometrize_py/native_bindings.cpp
+++ b/python/geometrize_py/native_bindings.cpp
@@ -1,0 +1,11 @@
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(_native, module)
+{
+    module.doc() = "Native bindings for the Geometrize image runner.";
+    module.def("is_available", []() {
+        return true;
+    });
+}

--- a/python/geometrize_py/native_bindings.cpp
+++ b/python/geometrize_py/native_bindings.cpp
@@ -1,6 +1,301 @@
+#include <algorithm>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "geometrize/bitmap/bitmap.h"
+#include "geometrize/runner/imagerunner.h"
+#include "geometrize/runner/imagerunneroptions.h"
+#include "geometrize/shape/circle.h"
+#include "geometrize/shape/ellipse.h"
+#include "geometrize/shape/line.h"
+#include "geometrize/shape/polyline.h"
+#include "geometrize/shape/quadraticbezier.h"
+#include "geometrize/shape/rectangle.h"
+#include "geometrize/shape/rotatedellipse.h"
+#include "geometrize/shape/rotatedrectangle.h"
+#include "geometrize/shape/shape.h"
+#include "geometrize/shape/shapetypes.h"
+#include "geometrize/shape/triangle.h"
+#include "geometrize/shaperesult.h"
 
 namespace py = pybind11;
+
+namespace {
+
+std::uint32_t uint_from_options(const py::dict& options, const char* name, const std::uint32_t defaultValue)
+{
+    if(!options.contains(name)) {
+        return defaultValue;
+    }
+    const int value = py::cast<int>(options[name]);
+    if(value < 0) {
+        throw std::invalid_argument(std::string{name} + " must be greater than or equal to zero");
+    }
+    return static_cast<std::uint32_t>(value);
+}
+
+std::uint8_t alpha_from_options(const py::dict& options)
+{
+    const int value = options.contains("alpha") ? py::cast<int>(options["alpha"]) : 128;
+    if(value < 0 || value > 255) {
+        throw std::invalid_argument("alpha must be between 0 and 255");
+    }
+    return static_cast<std::uint8_t>(value);
+}
+
+std::string normalize_shape_name(std::string value)
+{
+    std::replace(value.begin(), value.end(), '-', '_');
+    std::transform(value.begin(), value.end(), value.begin(), [](const unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return value;
+}
+
+geometrize::ShapeTypes shape_type_from_name(const std::string& name)
+{
+    const std::string normalized = normalize_shape_name(name);
+    if(normalized == "rectangle") {
+        return geometrize::ShapeTypes::RECTANGLE;
+    }
+    if(normalized == "rotated_rectangle") {
+        return geometrize::ShapeTypes::ROTATED_RECTANGLE;
+    }
+    if(normalized == "triangle") {
+        return geometrize::ShapeTypes::TRIANGLE;
+    }
+    if(normalized == "ellipse") {
+        return geometrize::ShapeTypes::ELLIPSE;
+    }
+    if(normalized == "rotated_ellipse") {
+        return geometrize::ShapeTypes::ROTATED_ELLIPSE;
+    }
+    if(normalized == "circle") {
+        return geometrize::ShapeTypes::CIRCLE;
+    }
+    if(normalized == "line") {
+        return geometrize::ShapeTypes::LINE;
+    }
+    if(normalized == "quadratic_bezier") {
+        return geometrize::ShapeTypes::QUADRATIC_BEZIER;
+    }
+    if(normalized == "polyline") {
+        return geometrize::ShapeTypes::POLYLINE;
+    }
+    throw std::invalid_argument("unknown shape type: " + name);
+}
+
+const char* shape_name(const geometrize::ShapeTypes type)
+{
+    switch(type) {
+    case geometrize::ShapeTypes::RECTANGLE:
+        return "rectangle";
+    case geometrize::ShapeTypes::ROTATED_RECTANGLE:
+        return "rotated_rectangle";
+    case geometrize::ShapeTypes::TRIANGLE:
+        return "triangle";
+    case geometrize::ShapeTypes::ELLIPSE:
+        return "ellipse";
+    case geometrize::ShapeTypes::ROTATED_ELLIPSE:
+        return "rotated_ellipse";
+    case geometrize::ShapeTypes::CIRCLE:
+        return "circle";
+    case geometrize::ShapeTypes::LINE:
+        return "line";
+    case geometrize::ShapeTypes::QUADRATIC_BEZIER:
+        return "quadratic_bezier";
+    case geometrize::ShapeTypes::POLYLINE:
+        return "polyline";
+    default:
+        return "unknown";
+    }
+}
+
+py::dict color_to_dict(const geometrize::rgba& color)
+{
+    py::dict data;
+    data["r"] = color.r;
+    data["g"] = color.g;
+    data["b"] = color.b;
+    data["a"] = color.a;
+    return data;
+}
+
+py::dict shape_data_to_dict(const geometrize::Shape& shape)
+{
+    py::dict data;
+    switch(shape.getType()) {
+    case geometrize::ShapeTypes::RECTANGLE: {
+        const auto& s = static_cast<const geometrize::Rectangle&>(shape);
+        data["x1"] = s.m_x1;
+        data["y1"] = s.m_y1;
+        data["x2"] = s.m_x2;
+        data["y2"] = s.m_y2;
+        return data;
+    }
+    case geometrize::ShapeTypes::ROTATED_RECTANGLE: {
+        const auto& s = static_cast<const geometrize::RotatedRectangle&>(shape);
+        data["x1"] = s.m_x1;
+        data["y1"] = s.m_y1;
+        data["x2"] = s.m_x2;
+        data["y2"] = s.m_y2;
+        data["angle"] = s.m_angle;
+        return data;
+    }
+    case geometrize::ShapeTypes::TRIANGLE: {
+        const auto& s = static_cast<const geometrize::Triangle&>(shape);
+        data["x1"] = s.m_x1;
+        data["y1"] = s.m_y1;
+        data["x2"] = s.m_x2;
+        data["y2"] = s.m_y2;
+        data["x3"] = s.m_x3;
+        data["y3"] = s.m_y3;
+        return data;
+    }
+    case geometrize::ShapeTypes::ELLIPSE: {
+        const auto& s = static_cast<const geometrize::Ellipse&>(shape);
+        data["x"] = s.m_x;
+        data["y"] = s.m_y;
+        data["rx"] = s.m_rx;
+        data["ry"] = s.m_ry;
+        return data;
+    }
+    case geometrize::ShapeTypes::ROTATED_ELLIPSE: {
+        const auto& s = static_cast<const geometrize::RotatedEllipse&>(shape);
+        data["x"] = s.m_x;
+        data["y"] = s.m_y;
+        data["rx"] = s.m_rx;
+        data["ry"] = s.m_ry;
+        data["angle"] = s.m_angle;
+        return data;
+    }
+    case geometrize::ShapeTypes::CIRCLE: {
+        const auto& s = static_cast<const geometrize::Circle&>(shape);
+        data["x"] = s.m_x;
+        data["y"] = s.m_y;
+        data["r"] = s.m_r;
+        return data;
+    }
+    case geometrize::ShapeTypes::LINE: {
+        const auto& s = static_cast<const geometrize::Line&>(shape);
+        data["x1"] = s.m_x1;
+        data["y1"] = s.m_y1;
+        data["x2"] = s.m_x2;
+        data["y2"] = s.m_y2;
+        return data;
+    }
+    case geometrize::ShapeTypes::QUADRATIC_BEZIER: {
+        const auto& s = static_cast<const geometrize::QuadraticBezier&>(shape);
+        data["x1"] = s.m_x1;
+        data["y1"] = s.m_y1;
+        data["cx"] = s.m_cx;
+        data["cy"] = s.m_cy;
+        data["x2"] = s.m_x2;
+        data["y2"] = s.m_y2;
+        return data;
+    }
+    case geometrize::ShapeTypes::POLYLINE: {
+        const auto& s = static_cast<const geometrize::Polyline&>(shape);
+        py::list points;
+        for(const auto& point : s.m_points) {
+            py::list item;
+            item.append(point.first);
+            item.append(point.second);
+            points.append(item);
+        }
+        data["points"] = points;
+        return data;
+    }
+    default:
+        throw std::runtime_error("unsupported shape type");
+    }
+}
+
+py::dict shape_result_to_dict(const geometrize::ShapeResult& result)
+{
+    py::dict data;
+    const geometrize::ShapeTypes type = result.shape->getType();
+    data["score"] = result.score;
+    data["color"] = color_to_dict(result.color);
+    data["type"] = shape_name(type);
+    data["type_id"] = static_cast<std::uint32_t>(type);
+    data["data"] = shape_data_to_dict(*result.shape);
+    return data;
+}
+
+geometrize::ImageRunnerOptions runner_options_from_dict(const py::dict& options)
+{
+    geometrize::ImageRunnerOptions runnerOptions;
+    const std::string shape = options.contains("shape") ? py::cast<std::string>(options["shape"]) : "ellipse";
+    runnerOptions.shapeTypes = shape_type_from_name(shape);
+    runnerOptions.alpha = alpha_from_options(options);
+    runnerOptions.shapeCount = uint_from_options(options, "candidate_shape_count", 50);
+    runnerOptions.maxShapeMutations = uint_from_options(options, "max_shape_mutations", 100);
+    runnerOptions.seed = uint_from_options(options, "seed", 9001);
+    runnerOptions.maxThreads = uint_from_options(options, "max_threads", 0);
+    return runnerOptions;
+}
+
+py::dict run_rgba(const std::uint32_t width, const std::uint32_t height, const py::bytes rgbaBytes, const py::dict options)
+{
+    if(width == 0 || height == 0) {
+        throw std::invalid_argument("width and height must be greater than zero");
+    }
+
+    const std::string rawData = rgbaBytes;
+    const std::size_t expectedLength = static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 4U;
+    if(rawData.size() != expectedLength) {
+        throw std::invalid_argument("rgba data length must equal width * height * 4");
+    }
+
+    const std::uint32_t targetShapeCount = uint_from_options(options, "count", 1);
+    if(targetShapeCount == 0) {
+        throw std::invalid_argument("count must be greater than zero");
+    }
+    const std::uint32_t maxAttempts = uint_from_options(options, "max_attempts", std::max<std::uint32_t>(targetShapeCount * 20U, targetShapeCount + 20U));
+    geometrize::ImageRunnerOptions runnerOptions = runner_options_from_dict(options);
+
+    std::vector<std::uint8_t> pixels(rawData.begin(), rawData.end());
+    geometrize::Bitmap target{width, height, pixels};
+    geometrize::ImageRunner runner{target};
+    std::vector<geometrize::ShapeResult> acceptedShapes;
+    acceptedShapes.reserve(targetShapeCount);
+    std::uint32_t attempts = 0;
+
+    {
+        py::gil_scoped_release release;
+        while(acceptedShapes.size() < targetShapeCount && attempts < maxAttempts) {
+            std::vector<geometrize::ShapeResult> results = runner.step(runnerOptions);
+            for(const geometrize::ShapeResult& result : results) {
+                if(acceptedShapes.size() < targetShapeCount) {
+                    acceptedShapes.push_back(result);
+                }
+            }
+            ++attempts;
+        }
+    }
+
+    const std::vector<std::uint8_t> current = runner.getCurrent().copyData();
+    py::list shapes;
+    for(const geometrize::ShapeResult& shape : acceptedShapes) {
+        shapes.append(shape_result_to_dict(shape));
+    }
+
+    py::dict result;
+    result["width"] = width;
+    result["height"] = height;
+    result["rgba"] = py::bytes(reinterpret_cast<const char*>(current.data()), current.size());
+    result["shapes"] = shapes;
+    result["attempts"] = attempts;
+    return result;
+}
+
+}
 
 PYBIND11_MODULE(_native, module)
 {
@@ -8,4 +303,5 @@ PYBIND11_MODULE(_native, module)
     module.def("is_available", []() {
         return true;
     });
+    module.def("run_rgba", &run_rgba, py::arg("width"), py::arg("height"), py::arg("rgba"), py::arg("options"));
 }

--- a/python/geometrize_py/screenshots.py
+++ b/python/geometrize_py/screenshots.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable
+
+
+SCREENSHOT_EXTENSIONS = {".png", ".jpg", ".jpeg", ".bmp", ".webp"}
+
+
+def default_screenshot_roots() -> list[Path]:
+    roots: list[Path] = []
+    user_profile = os.environ.get("USERPROFILE")
+    if user_profile:
+        roots.append(Path(user_profile) / "Pictures" / "Screenshots")
+
+    for env_name in ("OneDrive", "OneDriveConsumer", "OneDriveCommercial"):
+        one_drive = os.environ.get(env_name)
+        if one_drive:
+            roots.append(Path(one_drive) / "Pictures" / "Screenshots")
+
+    return _dedupe_existing_roots(roots)
+
+
+def find_latest_screenshot(roots: Iterable[Path] | None = None) -> Path | None:
+    search_roots = list(roots) if roots is not None else default_screenshot_roots()
+    latest_path: Path | None = None
+    latest_mtime = float("-inf")
+
+    for root in search_roots:
+        for candidate in _iter_screenshot_candidates(Path(root)):
+            try:
+                mtime = candidate.stat().st_mtime
+            except OSError:
+                continue
+            if mtime > latest_mtime:
+                latest_path = candidate
+                latest_mtime = mtime
+
+    return latest_path
+
+
+def _iter_screenshot_candidates(root: Path) -> Iterable[Path]:
+    if not root.exists():
+        return
+    if root.is_file():
+        if _looks_like_screenshot(root):
+            yield root
+        return
+
+    try:
+        paths = root.rglob("*")
+        for path in paths:
+            if path.is_file() and _looks_like_screenshot(path):
+                yield path
+    except OSError:
+        return
+
+
+def _looks_like_screenshot(path: Path) -> bool:
+    if path.suffix.lower() not in SCREENSHOT_EXTENSIONS:
+        return False
+    return "screenshot" in path.name.lower() or path.parent.name.lower() == "screenshots"
+
+
+def _dedupe_existing_roots(paths: Iterable[Path]) -> list[Path]:
+    roots: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        try:
+            resolved = path.resolve()
+        except OSError:
+            resolved = path
+        if resolved not in seen and path.exists():
+            roots.append(path)
+            seen.add(resolved)
+    return roots

--- a/python/geometrize_py/svg.py
+++ b/python/geometrize_py/svg.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from html import escape
+from math import cos, pi, sin
+from pathlib import Path
+from typing import Any
+
+
+STROKED_SHAPES = {"line", "polyline", "quadratic_bezier"}
+
+
+def render_svg(width: int, height: int, shapes: Iterable[Mapping[str, Any]]) -> str:
+    if width <= 0 or height <= 0:
+        raise ValueError("width and height must be greater than zero")
+
+    lines = [
+        (
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{_number(width)}" '
+            f'height="{_number(height)}" viewBox="0 0 {_number(width)} {_number(height)}">'
+        )
+    ]
+    for item_id, shape in enumerate(shapes):
+        lines.append(f"  {shape_to_svg_element(shape, item_id)}")
+    lines.append("</svg>")
+    return "\n".join(lines) + "\n"
+
+
+def export_svg(width: int, height: int, shapes: Iterable[Mapping[str, Any]]) -> str:
+    return render_svg(width, height, shapes)
+
+
+def save_svg(width: int, height: int, shapes: Iterable[Mapping[str, Any]], output_path: Path) -> None:
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(render_svg(width, height, shapes), encoding="utf-8")
+
+
+def shape_to_svg_element(shape: Mapping[str, Any], item_id: int = 0) -> str:
+    shape_type = str(shape["type"])
+    data = _mapping(shape["data"])
+    style = _style(shape_type, _mapping(shape["color"]), item_id)
+
+    if shape_type == "rectangle":
+        x1, y1, x2, y2 = _rect_bounds(data)
+        return (
+            f'<rect x="{_number(x1)}" y="{_number(y1)}" width="{_number(x2 - x1)}" '
+            f'height="{_number(y2 - y1)}" {style} />'
+        )
+    if shape_type == "rotated_rectangle":
+        points = " ".join(f"{_number(x)},{_number(y)}" for x, y in _rotated_rectangle_points(data))
+        return f'<polygon points="{escape(points)}" {style} />'
+    if shape_type == "triangle":
+        return (
+            '<polygon points="'
+            f'{_number(data["x1"])},{_number(data["y1"])} '
+            f'{_number(data["x2"])},{_number(data["y2"])} '
+            f'{_number(data["x3"])},{_number(data["y3"])}" {style} />'
+        )
+    if shape_type == "ellipse":
+        return (
+            f'<ellipse cx="{_number(data["x"])}" cy="{_number(data["y"])}" '
+            f'rx="{_number(data["rx"])}" ry="{_number(data["ry"])}" {style} />'
+        )
+    if shape_type == "rotated_ellipse":
+        return (
+            f'<g transform="translate({_number(data["x"])} {_number(data["y"])}) '
+            f'rotate({_number(data["angle"])}) scale({_number(data["rx"])} {_number(data["ry"])})">'
+            f'<ellipse cx="0" cy="0" rx="1" ry="1" {style} /></g>'
+        )
+    if shape_type == "circle":
+        return (
+            f'<circle cx="{_number(data["x"])}" cy="{_number(data["y"])}" '
+            f'r="{_number(data["r"])}" {style} />'
+        )
+    if shape_type == "line":
+        return (
+            f'<line x1="{_number(data["x1"])}" y1="{_number(data["y1"])}" '
+            f'x2="{_number(data["x2"])}" y2="{_number(data["y2"])}" {style} />'
+        )
+    if shape_type == "polyline":
+        points = " ".join(f"{_number(point[0])},{_number(point[1])}" for point in data["points"])
+        return f'<polyline points="{escape(points)}" {style} />'
+    if shape_type == "quadratic_bezier":
+        path = (
+            f'M{_number(data["x1"])} {_number(data["y1"])} '
+            f'Q {_number(data["cx"])} {_number(data["cy"])} {_number(data["x2"])} {_number(data["y2"])}'
+        )
+        return f'<path d="{escape(path)}" {style} />'
+
+    raise ValueError(f"unsupported shape type for SVG export: {shape_type}")
+
+
+def _style(shape_type: str, color: Mapping[str, Any], item_id: int) -> str:
+    rgb = f'rgb({int(color["r"])},{int(color["g"])},{int(color["b"])})'
+    opacity = _number(int(color["a"]) / 255)
+    if shape_type in STROKED_SHAPES:
+        return f'id="{item_id}" stroke="{rgb}" stroke-width="1" fill="none" stroke-opacity="{opacity}"'
+    return f'id="{item_id}" fill="{rgb}" fill-opacity="{opacity}"'
+
+
+def _rect_bounds(data: Mapping[str, Any]) -> tuple[float, float, float, float]:
+    x1 = float(data["x1"])
+    y1 = float(data["y1"])
+    x2 = float(data["x2"])
+    y2 = float(data["y2"])
+    return min(x1, x2), min(y1, y2), max(x1, x2), max(y1, y2)
+
+
+def _rotated_rectangle_points(data: Mapping[str, Any]) -> list[tuple[float, float]]:
+    x1, y1, x2, y2 = _rect_bounds(data)
+    cx = (x2 + x1) / 2
+    cy = (y2 + y1) / 2
+    ox1 = x1 - cx
+    ox2 = x2 - cx
+    oy1 = y1 - cy
+    oy2 = y2 - cy
+    rads = float(data["angle"]) * pi / 180
+    cosine = cos(rads)
+    sine = sin(rads)
+    return [
+        (ox1 * cosine - oy1 * sine + cx, ox1 * sine + oy1 * cosine + cy),
+        (ox2 * cosine - oy1 * sine + cx, ox2 * sine + oy1 * cosine + cy),
+        (ox2 * cosine - oy2 * sine + cx, ox2 * sine + oy2 * cosine + cy),
+        (ox1 * cosine - oy2 * sine + cx, ox1 * sine + oy2 * cosine + cy),
+    ]
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("shape data must be a mapping")
+    return value
+
+
+def _number(value: Any) -> str:
+    numeric = float(value)
+    if numeric.is_integer():
+        return str(int(numeric))
+    return f"{numeric:.6f}".rstrip("0").rstrip(".")

--- a/tests/python/helpers.py
+++ b/tests/python/helpers.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from PIL import Image
+
+
+def write_tiny_split_image(path: Path) -> None:
+    image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
+    for x in range(2, 4):
+        for y in range(4):
+            image.putpixel((x, y), (255, 255, 255, 255))
+    image.save(path)

--- a/tests/python/test_batch.py
+++ b/tests/python/test_batch.py
@@ -1,0 +1,64 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from PIL import Image
+
+from geometrize_py.batch import BatchManifest, load_batch_manifest
+from geometrize_py.jobs import ExportFormat, ShapeType
+
+
+class BatchManifestTests(unittest.TestCase):
+    def test_load_batch_manifest_merges_defaults_and_resolves_relative_paths(self):
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            manifest_path = root_path / "batch.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "defaults": {"shape": "triangle", "count": 5, "export_format": "svg"},
+                        "jobs": [{"input_path": "input.png", "output_path": "out.svg"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = load_batch_manifest(manifest_path)
+
+        self.assertIsInstance(manifest, BatchManifest)
+        self.assertEqual(len(manifest.jobs), 1)
+        self.assertEqual(manifest.jobs[0].input_path, root_path / "input.png")
+        self.assertEqual(manifest.jobs[0].output_path, root_path / "out.svg")
+        self.assertEqual(manifest.jobs[0].shape, ShapeType.TRIANGLE)
+        self.assertEqual(manifest.jobs[0].count, 5)
+        self.assertEqual(manifest.jobs[0].export_format, ExportFormat.SVG)
+
+    def test_load_batch_manifest_rejects_empty_jobs(self):
+        with tempfile.TemporaryDirectory() as root:
+            manifest_path = Path(root) / "batch.json"
+            manifest_path.write_text(json.dumps({"version": 1, "jobs": []}), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "jobs"):
+                load_batch_manifest(manifest_path)
+
+    def test_load_batch_manifest_rejects_non_object_job(self):
+        with tempfile.TemporaryDirectory() as root:
+            manifest_path = Path(root) / "batch.json"
+            manifest_path.write_text(json.dumps({"version": 1, "jobs": ["bad"]}), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "job 0"):
+                load_batch_manifest(manifest_path)
+
+
+def write_tiny_image(path: Path) -> None:
+    image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
+    for x in range(2, 4):
+        for y in range(4):
+            image.putpixel((x, y), (255, 255, 255, 255))
+    image.save(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_batch.py
+++ b/tests/python/test_batch.py
@@ -3,8 +3,6 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from PIL import Image
-
 from geometrize_py.batch import BatchManifest, load_batch_manifest
 from geometrize_py.jobs import ExportFormat, ShapeType
 
@@ -50,14 +48,6 @@ class BatchManifestTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, "job 0"):
                 load_batch_manifest(manifest_path)
-
-
-def write_tiny_image(path: Path) -> None:
-    image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
-    for x in range(2, 4):
-        for y in range(4):
-            image.putpixel((x, y), (255, 255, 255, 255))
-    image.save(path)
 
 
 if __name__ == "__main__":

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -44,11 +44,17 @@ class CliTests(unittest.TestCase):
         self.assertEqual(plan["export_format"], "png")
         self.assertEqual(plan["runner"], "dry-run")
 
-    def test_run_without_native_core_fails_clearly(self):
+    def test_run_writes_png_output(self):
+        from PIL import Image
+
         with tempfile.TemporaryDirectory() as root:
             input_path = Path(root) / "source.png"
             output_path = Path(root) / "out.png"
-            input_path.write_bytes(b"not a real image yet")
+            image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
+            for x in range(2, 4):
+                for y in range(4):
+                    image.putpixel((x, y), (255, 255, 255, 255))
+            image.save(input_path)
 
             exit_code, stdout, stderr = self.run_cli(
                 [
@@ -58,15 +64,24 @@ class CliTests(unittest.TestCase):
                     "--output",
                     str(output_path),
                     "--shape",
-                    "triangle",
+                    "rectangle",
                     "--count",
-                    "4000",
+                    "1",
+                    "--candidate-shape-count",
+                    "10",
+                    "--max-shape-mutations",
+                    "25",
+                    "--max-threads",
+                    "1",
                 ]
             )
 
-        self.assertEqual(exit_code, 2)
-        self.assertEqual(stdout, "")
-        self.assertIn("native core", stderr.lower())
+            self.assertTrue(output_path.exists())
+
+        self.assertEqual(exit_code, 0, stderr)
+        result = json.loads(stdout)
+        self.assertEqual(result["output_path"], str(output_path))
+        self.assertLessEqual(result["shapes_written"], 1)
 
     def test_run_dry_run_accepts_job_manifest(self):
         with tempfile.TemporaryDirectory() as root:

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -1,0 +1,73 @@
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+from geometrize_py.cli import main
+
+
+class CliTests(unittest.TestCase):
+    def run_cli(self, args):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            exit_code = main(args)
+        return exit_code, stdout.getvalue(), stderr.getvalue()
+
+    def test_run_dry_run_prints_job_plan(self):
+        with tempfile.TemporaryDirectory() as root:
+            input_path = Path(root) / "source.png"
+            output_path = Path(root) / "out.png"
+            input_path.write_bytes(b"not a real image yet")
+
+            exit_code, stdout, stderr = self.run_cli(
+                [
+                    "run",
+                    "--input",
+                    str(input_path),
+                    "--output",
+                    str(output_path),
+                    "--shape",
+                    "triangle",
+                    "--count",
+                    "4000",
+                    "--dry-run",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0, stderr)
+        plan = json.loads(stdout)
+        self.assertEqual(plan["shape"], "triangle")
+        self.assertEqual(plan["count"], 4000)
+        self.assertEqual(plan["export_format"], "png")
+        self.assertEqual(plan["runner"], "dry-run")
+
+    def test_run_without_native_core_fails_clearly(self):
+        with tempfile.TemporaryDirectory() as root:
+            input_path = Path(root) / "source.png"
+            output_path = Path(root) / "out.png"
+            input_path.write_bytes(b"not a real image yet")
+
+            exit_code, stdout, stderr = self.run_cli(
+                [
+                    "run",
+                    "--input",
+                    str(input_path),
+                    "--output",
+                    str(output_path),
+                    "--shape",
+                    "triangle",
+                    "--count",
+                    "4000",
+                ]
+            )
+
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("native core", stderr.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -126,6 +126,47 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["height"], 4)
         self.assertLessEqual(len(payload["shapes"]), 1)
 
+    def test_run_writes_svg_output(self):
+        from PIL import Image
+
+        with tempfile.TemporaryDirectory() as root:
+            input_path = Path(root) / "source.png"
+            output_path = Path(root) / "out.svg"
+            image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
+            for x in range(2, 4):
+                for y in range(4):
+                    image.putpixel((x, y), (255, 255, 255, 255))
+            image.save(input_path)
+
+            exit_code, stdout, stderr = self.run_cli(
+                [
+                    "run",
+                    "--input",
+                    str(input_path),
+                    "--output",
+                    str(output_path),
+                    "--shape",
+                    "rectangle",
+                    "--count",
+                    "1",
+                    "--export-format",
+                    "svg",
+                    "--candidate-shape-count",
+                    "10",
+                    "--max-shape-mutations",
+                    "25",
+                    "--max-threads",
+                    "1",
+                ]
+            )
+
+            svg = output_path.read_text(encoding="utf-8")
+
+        self.assertEqual(exit_code, 0, stderr)
+        result = json.loads(stdout)
+        self.assertEqual(result["output_path"], str(output_path))
+        self.assertIn("<svg", svg)
+
     def test_run_dry_run_accepts_job_manifest(self):
         with tempfile.TemporaryDirectory() as root:
             input_path = Path(root) / "source.png"

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -6,7 +6,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 from geometrize_py.cli import main
-from test_batch import write_tiny_image
+from helpers import write_tiny_split_image
 
 
 class CliTests(unittest.TestCase):
@@ -46,16 +46,10 @@ class CliTests(unittest.TestCase):
         self.assertEqual(plan["runner"], "dry-run")
 
     def test_run_writes_png_output(self):
-        from PIL import Image
-
         with tempfile.TemporaryDirectory() as root:
             input_path = Path(root) / "source.png"
             output_path = Path(root) / "out.png"
-            image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
-            for x in range(2, 4):
-                for y in range(4):
-                    image.putpixel((x, y), (255, 255, 255, 255))
-            image.save(input_path)
+            write_tiny_split_image(input_path)
 
             exit_code, stdout, stderr = self.run_cli(
                 [
@@ -85,16 +79,10 @@ class CliTests(unittest.TestCase):
         self.assertLessEqual(result["shapes_written"], 1)
 
     def test_run_writes_json_output(self):
-        from PIL import Image
-
         with tempfile.TemporaryDirectory() as root:
             input_path = Path(root) / "source.png"
             output_path = Path(root) / "out.json"
-            image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
-            for x in range(2, 4):
-                for y in range(4):
-                    image.putpixel((x, y), (255, 255, 255, 255))
-            image.save(input_path)
+            write_tiny_split_image(input_path)
 
             exit_code, stdout, stderr = self.run_cli(
                 [
@@ -128,16 +116,10 @@ class CliTests(unittest.TestCase):
         self.assertLessEqual(len(payload["shapes"]), 1)
 
     def test_run_writes_svg_output(self):
-        from PIL import Image
-
         with tempfile.TemporaryDirectory() as root:
             input_path = Path(root) / "source.png"
             output_path = Path(root) / "out.svg"
-            image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
-            for x in range(2, 4):
-                for y in range(4):
-                    image.putpixel((x, y), (255, 255, 255, 255))
-            image.save(input_path)
+            write_tiny_split_image(input_path)
 
             exit_code, stdout, stderr = self.run_cli(
                 [
@@ -224,8 +206,8 @@ class CliTests(unittest.TestCase):
             input_b = root_path / "b.png"
             output_a = root_path / "a_out.png"
             output_b = root_path / "b_out.svg"
-            write_tiny_image(input_a)
-            write_tiny_image(input_b)
+            write_tiny_split_image(input_a)
+            write_tiny_split_image(input_b)
             manifest_path = root_path / "batch.json"
             manifest_path.write_text(
                 json.dumps(
@@ -262,7 +244,7 @@ class CliTests(unittest.TestCase):
             root_path = Path(root)
             input_ok = root_path / "ok.png"
             output_ok = root_path / "ok_out.png"
-            write_tiny_image(input_ok)
+            write_tiny_split_image(input_ok)
             manifest_path = root_path / "batch.json"
             manifest_path.write_text(
                 json.dumps(
@@ -300,7 +282,7 @@ class CliTests(unittest.TestCase):
             root_path = Path(root)
             input_ok = root_path / "ok.png"
             output_ok = root_path / "ok_out.png"
-            write_tiny_image(input_ok)
+            write_tiny_split_image(input_ok)
             manifest_path = root_path / "batch.json"
             manifest_path.write_text(
                 json.dumps(

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -68,6 +68,31 @@ class CliTests(unittest.TestCase):
         self.assertEqual(stdout, "")
         self.assertIn("native core", stderr.lower())
 
+    def test_run_dry_run_accepts_job_manifest(self):
+        with tempfile.TemporaryDirectory() as root:
+            input_path = Path(root) / "source.png"
+            output_path = Path(root) / "out.png"
+            manifest_path = Path(root) / "job.json"
+            input_path.write_bytes(b"not a real image yet")
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "input_path": str(input_path),
+                        "output_path": str(output_path),
+                        "shape": "triangle",
+                        "count": 4000,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            exit_code, stdout, stderr = self.run_cli(["run", "--job", str(manifest_path), "--dry-run"])
+
+        self.assertEqual(exit_code, 0, stderr)
+        plan = json.loads(stdout)
+        self.assertEqual(plan["shape"], "triangle")
+        self.assertEqual(plan["count"], 4000)
+
     def test_inspect_prints_image_metadata(self):
         from PIL import Image
 

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -68,6 +68,21 @@ class CliTests(unittest.TestCase):
         self.assertEqual(stdout, "")
         self.assertIn("native core", stderr.lower())
 
+    def test_inspect_prints_image_metadata(self):
+        from PIL import Image
+
+        with tempfile.TemporaryDirectory() as root:
+            input_path = Path(root) / "source.png"
+            Image.new("RGBA", (3, 4), (1, 2, 3, 4)).save(input_path)
+
+            exit_code, stdout, stderr = self.run_cli(["inspect", str(input_path)])
+
+        self.assertEqual(exit_code, 0, stderr)
+        info = json.loads(stdout)
+        self.assertEqual(info["width"], 3)
+        self.assertEqual(info["height"], 4)
+        self.assertEqual(info["mode"], "RGBA")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -6,6 +6,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 from geometrize_py.cli import main
+from test_batch import write_tiny_image
 
 
 class CliTests(unittest.TestCase):
@@ -191,6 +192,144 @@ class CliTests(unittest.TestCase):
         plan = json.loads(stdout)
         self.assertEqual(plan["shape"], "triangle")
         self.assertEqual(plan["count"], 4000)
+
+    def test_batch_dry_run_prints_resolved_plans(self):
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            manifest_path = root_path / "batch.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "defaults": {"shape": "triangle", "count": 5, "export_format": "svg"},
+                        "jobs": [{"input_path": "input.png", "output_path": "out.svg"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            exit_code, stdout, stderr = self.run_cli(["batch", "--manifest", str(manifest_path), "--dry-run"])
+
+        self.assertEqual(exit_code, 0, stderr)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["jobs_total"], 1)
+        self.assertEqual(payload["plans"][0]["input_path"], str(root_path / "input.png"))
+        self.assertEqual(payload["plans"][0]["shape"], "triangle")
+        self.assertEqual(payload["plans"][0]["export_format"], "svg")
+
+    def test_batch_writes_png_and_svg_outputs(self):
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            input_a = root_path / "a.png"
+            input_b = root_path / "b.png"
+            output_a = root_path / "a_out.png"
+            output_b = root_path / "b_out.svg"
+            write_tiny_image(input_a)
+            write_tiny_image(input_b)
+            manifest_path = root_path / "batch.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "defaults": {
+                            "shape": "rectangle",
+                            "count": 1,
+                            "candidate_shape_count": 10,
+                            "max_shape_mutations": 25,
+                            "max_threads": 1,
+                        },
+                        "jobs": [
+                            {"input_path": "a.png", "output_path": "a_out.png"},
+                            {"input_path": "b.png", "output_path": "b_out.svg", "export_format": "svg"},
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            exit_code, stdout, stderr = self.run_cli(["batch", "--manifest", str(manifest_path)])
+
+            self.assertTrue(output_a.exists())
+            self.assertTrue(output_b.exists())
+
+        self.assertEqual(exit_code, 0, stderr)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["jobs_succeeded"], 2)
+        self.assertEqual(payload["jobs_failed"], 0)
+
+    def test_batch_continue_on_error_returns_1(self):
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            input_ok = root_path / "ok.png"
+            output_ok = root_path / "ok_out.png"
+            write_tiny_image(input_ok)
+            manifest_path = root_path / "batch.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "defaults": {
+                            "shape": "rectangle",
+                            "count": 1,
+                            "candidate_shape_count": 10,
+                            "max_shape_mutations": 25,
+                            "max_threads": 1,
+                        },
+                        "jobs": [
+                            {"input_path": "missing.png", "output_path": "missing_out.png"},
+                            {"input_path": "ok.png", "output_path": "ok_out.png"},
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            exit_code, stdout, stderr = self.run_cli(
+                ["batch", "--manifest", str(manifest_path), "--continue-on-error"]
+            )
+
+            self.assertTrue(output_ok.exists())
+
+        self.assertEqual(exit_code, 1, stderr)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["jobs_succeeded"], 1)
+        self.assertEqual(payload["jobs_failed"], 1)
+
+    def test_batch_stops_on_first_error_without_continue(self):
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            input_ok = root_path / "ok.png"
+            output_ok = root_path / "ok_out.png"
+            write_tiny_image(input_ok)
+            manifest_path = root_path / "batch.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "defaults": {
+                            "shape": "rectangle",
+                            "count": 1,
+                            "candidate_shape_count": 10,
+                            "max_shape_mutations": 25,
+                            "max_threads": 1,
+                        },
+                        "jobs": [
+                            {"input_path": "missing.png", "output_path": "missing_out.png"},
+                            {"input_path": "ok.png", "output_path": "ok_out.png"},
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            exit_code, stdout, stderr = self.run_cli(["batch", "--manifest", str(manifest_path)])
+
+            self.assertFalse(output_ok.exists())
+
+        self.assertEqual(exit_code, 2, stderr)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["jobs_succeeded"], 0)
+        self.assertEqual(payload["jobs_failed"], 1)
 
     def test_inspect_prints_image_metadata(self):
         from PIL import Image

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -83,6 +83,49 @@ class CliTests(unittest.TestCase):
         self.assertEqual(result["output_path"], str(output_path))
         self.assertLessEqual(result["shapes_written"], 1)
 
+    def test_run_writes_json_output(self):
+        from PIL import Image
+
+        with tempfile.TemporaryDirectory() as root:
+            input_path = Path(root) / "source.png"
+            output_path = Path(root) / "out.json"
+            image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
+            for x in range(2, 4):
+                for y in range(4):
+                    image.putpixel((x, y), (255, 255, 255, 255))
+            image.save(input_path)
+
+            exit_code, stdout, stderr = self.run_cli(
+                [
+                    "run",
+                    "--input",
+                    str(input_path),
+                    "--output",
+                    str(output_path),
+                    "--shape",
+                    "rectangle",
+                    "--count",
+                    "1",
+                    "--export-format",
+                    "json",
+                    "--candidate-shape-count",
+                    "10",
+                    "--max-shape-mutations",
+                    "25",
+                    "--max-threads",
+                    "1",
+                ]
+            )
+
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0, stderr)
+        result = json.loads(stdout)
+        self.assertEqual(result["output_path"], str(output_path))
+        self.assertEqual(payload["width"], 4)
+        self.assertEqual(payload["height"], 4)
+        self.assertLessEqual(len(payload["shapes"]), 1)
+
     def test_run_dry_run_accepts_job_manifest(self):
         with tempfile.TemporaryDirectory() as root:
             input_path = Path(root) / "source.png"

--- a/tests/python/test_images.py
+++ b/tests/python/test_images.py
@@ -1,0 +1,47 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from PIL import Image
+
+from geometrize_py.images import RgbaImage, inspect_image, load_rgba_image, save_rgba_image
+
+
+class ImageIoTests(unittest.TestCase):
+    def test_load_rgba_image_returns_dimensions_and_bytes(self):
+        with tempfile.TemporaryDirectory() as root:
+            image_path = Path(root) / "source.png"
+            Image.new("RGB", (2, 1), (10, 20, 30)).save(image_path)
+
+            image = load_rgba_image(image_path)
+
+        self.assertEqual(image.width, 2)
+        self.assertEqual(image.height, 1)
+        self.assertEqual(image.rgba, bytes([10, 20, 30, 255, 10, 20, 30, 255]))
+
+    def test_inspect_image_does_not_materialize_rgba_bytes(self):
+        with tempfile.TemporaryDirectory() as root:
+            image_path = Path(root) / "source.png"
+            Image.new("RGBA", (3, 4), (1, 2, 3, 4)).save(image_path)
+
+            info = inspect_image(image_path)
+
+        self.assertEqual(info.width, 3)
+        self.assertEqual(info.height, 4)
+        self.assertEqual(info.mode, "RGBA")
+        self.assertEqual(info.format, "PNG")
+
+    def test_save_rgba_image_writes_png(self):
+        with tempfile.TemporaryDirectory() as root:
+            output_path = Path(root) / "out.png"
+            image = RgbaImage(width=1, height=1, rgba=bytes([5, 6, 7, 255]))
+
+            save_rgba_image(image, output_path)
+
+            with Image.open(output_path) as saved:
+                self.assertEqual(saved.size, (1, 1))
+                self.assertEqual(saved.convert("RGBA").getpixel((0, 0)), (5, 6, 7, 255))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_job_config.py
+++ b/tests/python/test_job_config.py
@@ -1,0 +1,39 @@
+import unittest
+from pathlib import Path
+
+from geometrize_py.jobs import ExportFormat, GeometrizeJob, ShapeType
+
+
+class GeometrizeJobTests(unittest.TestCase):
+    def test_creates_triangle_job_with_expected_defaults(self):
+        job = GeometrizeJob(
+            input_path=Path("input.png"),
+            output_path=Path("output.png"),
+            shape=ShapeType.TRIANGLE,
+            count=4000,
+        )
+
+        self.assertEqual(job.shape, ShapeType.TRIANGLE)
+        self.assertEqual(job.count, 4000)
+        self.assertEqual(job.export_format, ExportFormat.PNG)
+        self.assertEqual(job.alpha, 128)
+        self.assertEqual(job.candidate_shape_count, 50)
+        self.assertEqual(job.max_shape_mutations, 100)
+
+    def test_rejects_non_positive_shape_count(self):
+        with self.assertRaisesRegex(ValueError, "count"):
+            GeometrizeJob(
+                input_path=Path("input.png"),
+                output_path=Path("output.png"),
+                shape=ShapeType.TRIANGLE,
+                count=0,
+            )
+
+    def test_shape_lookup_uses_cli_names(self):
+        self.assertEqual(ShapeType.from_cli("triangle"), ShapeType.TRIANGLE)
+        self.assertEqual(ShapeType.from_cli("rotated-rectangle"), ShapeType.ROTATED_RECTANGLE)
+        self.assertEqual(ShapeType.from_cli("rotated_rectangle"), ShapeType.ROTATED_RECTANGLE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_manifests.py
+++ b/tests/python/test_manifests.py
@@ -1,0 +1,82 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from geometrize_py.jobs import ExportFormat, GeometrizeJob, ShapeType
+from geometrize_py.manifests import load_job, save_job
+
+
+class ManifestTests(unittest.TestCase):
+    def test_save_and_load_job_manifest(self):
+        with tempfile.TemporaryDirectory() as root:
+            manifest_path = Path(root) / "job.json"
+            job = GeometrizeJob(
+                input_path=Path(root) / "input.png",
+                output_path=Path(root) / "output.svg",
+                shape=ShapeType.ROTATED_RECTANGLE,
+                count=250,
+                export_format=ExportFormat.SVG,
+                alpha=180,
+            )
+
+            save_job(job, manifest_path)
+            loaded = load_job(manifest_path)
+
+        self.assertEqual(loaded.input_path, job.input_path)
+        self.assertEqual(loaded.output_path, job.output_path)
+        self.assertEqual(loaded.shape, ShapeType.ROTATED_RECTANGLE)
+        self.assertEqual(loaded.count, 250)
+        self.assertEqual(loaded.export_format, ExportFormat.SVG)
+        self.assertEqual(loaded.alpha, 180)
+
+    def test_load_job_accepts_cli_shape_names(self):
+        with tempfile.TemporaryDirectory() as root:
+            manifest_path = Path(root) / "job.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "input_path": str(Path(root) / "in.png"),
+                        "output_path": str(Path(root) / "out.png"),
+                        "shape": "rotated-rectangle",
+                        "count": 50,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            job = load_job(manifest_path)
+
+        self.assertEqual(job.shape, ShapeType.ROTATED_RECTANGLE)
+        self.assertEqual(job.export_format, ExportFormat.PNG)
+
+    def test_load_job_rejects_missing_required_fields(self):
+        with tempfile.TemporaryDirectory() as root:
+            manifest_path = Path(root) / "job.json"
+            manifest_path.write_text("{}", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "input_path"):
+                load_job(manifest_path)
+
+    def test_load_job_accepts_utf8_bom_from_windows_tools(self):
+        with tempfile.TemporaryDirectory() as root:
+            manifest_path = Path(root) / "job.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "input_path": str(Path(root) / "in.png"),
+                        "output_path": str(Path(root) / "out.png"),
+                        "shape": "triangle",
+                        "count": 10,
+                    }
+                ),
+                encoding="utf-8-sig",
+            )
+
+            job = load_job(manifest_path)
+
+        self.assertEqual(job.shape, ShapeType.TRIANGLE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_native_backend.py
+++ b/tests/python/test_native_backend.py
@@ -1,0 +1,12 @@
+import unittest
+
+from geometrize_py import native
+
+
+class NativeBackendTests(unittest.TestCase):
+    def test_native_backend_reports_available(self):
+        self.assertTrue(native.is_native_core_available())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_native_backend.py
+++ b/tests/python/test_native_backend.py
@@ -1,11 +1,62 @@
 import unittest
 
 from geometrize_py import native
+from geometrize_py.images import RgbaImage
 
 
 class NativeBackendTests(unittest.TestCase):
     def test_native_backend_reports_available(self):
         self.assertTrue(native.is_native_core_available())
+
+    def test_native_backend_runs_tiny_rgba_job(self):
+        from geometrize_py import _native
+
+        image = RgbaImage(
+            width=4,
+            height=4,
+            rgba=bytes(
+                [
+                    0,
+                    0,
+                    0,
+                    255,
+                    0,
+                    0,
+                    0,
+                    255,
+                    255,
+                    255,
+                    255,
+                    255,
+                    255,
+                    255,
+                    255,
+                    255,
+                ]
+                * 4
+            ),
+        )
+
+        result = _native.run_rgba(
+            image.width,
+            image.height,
+            image.rgba,
+            {
+                "shape": "rectangle",
+                "count": 1,
+                "alpha": 128,
+                "candidate_shape_count": 10,
+                "max_shape_mutations": 25,
+                "seed": 1,
+                "max_threads": 1,
+            },
+        )
+
+        self.assertEqual(result["width"], image.width)
+        self.assertEqual(result["height"], image.height)
+        self.assertEqual(len(result["rgba"]), len(image.rgba))
+        self.assertLessEqual(len(result["shapes"]), 1)
+        self.assertIsInstance(result["shapes"], list)
 
 
 if __name__ == "__main__":

--- a/tests/python/test_native_runner.py
+++ b/tests/python/test_native_runner.py
@@ -1,10 +1,11 @@
 import tempfile
 import unittest
+import json
 from pathlib import Path
 
 from PIL import Image
 
-from geometrize_py.jobs import GeometrizeJob, ShapeType
+from geometrize_py.jobs import ExportFormat, GeometrizeJob, ShapeType
 from geometrize_py.native import NativeRunner
 
 
@@ -34,6 +35,36 @@ class NativeRunnerTests(unittest.TestCase):
             self.assertEqual(result.output_path, output_path)
             self.assertTrue(output_path.exists())
             self.assertLessEqual(result.shapes_written, 1)
+
+    def test_runner_writes_json_shape_output(self):
+        with tempfile.TemporaryDirectory() as root:
+            input_path = Path(root) / "input.png"
+            output_path = Path(root) / "output.json"
+            image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
+            for x in range(2, 4):
+                for y in range(4):
+                    image.putpixel((x, y), (255, 255, 255, 255))
+            image.save(input_path)
+
+            result = NativeRunner().run(
+                GeometrizeJob(
+                    input_path=input_path,
+                    output_path=output_path,
+                    shape=ShapeType.RECTANGLE,
+                    count=1,
+                    export_format=ExportFormat.JSON,
+                    candidate_shape_count=10,
+                    max_shape_mutations=25,
+                    max_threads=1,
+                )
+            )
+
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.output_path, output_path)
+        self.assertEqual(payload["width"], 4)
+        self.assertEqual(payload["height"], 4)
+        self.assertLessEqual(len(payload["shapes"]), 1)
 
 
 if __name__ == "__main__":

--- a/tests/python/test_native_runner.py
+++ b/tests/python/test_native_runner.py
@@ -3,10 +3,9 @@ import unittest
 import json
 from pathlib import Path
 
-from PIL import Image
-
 from geometrize_py.jobs import ExportFormat, GeometrizeJob, ShapeType
 from geometrize_py.native import NativeRunner
+from helpers import write_tiny_split_image
 
 
 class NativeRunnerTests(unittest.TestCase):
@@ -14,11 +13,7 @@ class NativeRunnerTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as root:
             input_path = Path(root) / "input.png"
             output_path = Path(root) / "output.png"
-            image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
-            for x in range(2, 4):
-                for y in range(4):
-                    image.putpixel((x, y), (255, 255, 255, 255))
-            image.save(input_path)
+            write_tiny_split_image(input_path)
 
             result = NativeRunner().run(
                 GeometrizeJob(
@@ -40,11 +35,7 @@ class NativeRunnerTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as root:
             input_path = Path(root) / "input.png"
             output_path = Path(root) / "output.json"
-            image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
-            for x in range(2, 4):
-                for y in range(4):
-                    image.putpixel((x, y), (255, 255, 255, 255))
-            image.save(input_path)
+            write_tiny_split_image(input_path)
 
             result = NativeRunner().run(
                 GeometrizeJob(
@@ -70,11 +61,7 @@ class NativeRunnerTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as root:
             input_path = Path(root) / "input.png"
             output_path = Path(root) / "output.svg"
-            image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
-            for x in range(2, 4):
-                for y in range(4):
-                    image.putpixel((x, y), (255, 255, 255, 255))
-            image.save(input_path)
+            write_tiny_split_image(input_path)
 
             result = NativeRunner().run(
                 GeometrizeJob(

--- a/tests/python/test_native_runner.py
+++ b/tests/python/test_native_runner.py
@@ -66,6 +66,36 @@ class NativeRunnerTests(unittest.TestCase):
         self.assertEqual(payload["height"], 4)
         self.assertLessEqual(len(payload["shapes"]), 1)
 
+    def test_runner_writes_svg_output(self):
+        with tempfile.TemporaryDirectory() as root:
+            input_path = Path(root) / "input.png"
+            output_path = Path(root) / "output.svg"
+            image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
+            for x in range(2, 4):
+                for y in range(4):
+                    image.putpixel((x, y), (255, 255, 255, 255))
+            image.save(input_path)
+
+            result = NativeRunner().run(
+                GeometrizeJob(
+                    input_path=input_path,
+                    output_path=output_path,
+                    shape=ShapeType.RECTANGLE,
+                    count=1,
+                    export_format=ExportFormat.SVG,
+                    candidate_shape_count=10,
+                    max_shape_mutations=25,
+                    max_threads=1,
+                )
+            )
+
+            svg = output_path.read_text(encoding="utf-8")
+
+        self.assertEqual(result.output_path, output_path)
+        self.assertIn("<svg", svg)
+        self.assertIn("width=\"4\"", svg)
+        self.assertIn("height=\"4\"", svg)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/python/test_native_runner.py
+++ b/tests/python/test_native_runner.py
@@ -1,0 +1,40 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from PIL import Image
+
+from geometrize_py.jobs import GeometrizeJob, ShapeType
+from geometrize_py.native import NativeRunner
+
+
+class NativeRunnerTests(unittest.TestCase):
+    def test_runner_writes_png_output(self):
+        with tempfile.TemporaryDirectory() as root:
+            input_path = Path(root) / "input.png"
+            output_path = Path(root) / "output.png"
+            image = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
+            for x in range(2, 4):
+                for y in range(4):
+                    image.putpixel((x, y), (255, 255, 255, 255))
+            image.save(input_path)
+
+            result = NativeRunner().run(
+                GeometrizeJob(
+                    input_path=input_path,
+                    output_path=output_path,
+                    shape=ShapeType.RECTANGLE,
+                    count=1,
+                    candidate_shape_count=10,
+                    max_shape_mutations=25,
+                    max_threads=1,
+                )
+            )
+
+            self.assertEqual(result.output_path, output_path)
+            self.assertTrue(output_path.exists())
+            self.assertLessEqual(result.shapes_written, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_screenshots.py
+++ b/tests/python/test_screenshots.py
@@ -1,0 +1,39 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from geometrize_py.screenshots import find_latest_screenshot
+
+
+class ScreenshotDiscoveryTests(unittest.TestCase):
+    def test_finds_newest_screenshot_image_across_roots(self):
+        with tempfile.TemporaryDirectory() as first_root, tempfile.TemporaryDirectory() as second_root:
+            older = Path(first_root) / "Screenshot 2026-05-01 112113.png"
+            newer = Path(second_root) / "Screenshot 2026-05-01 112445.png"
+            ignored = Path(second_root) / "notes.png"
+
+            older.write_bytes(b"older")
+            newer.write_bytes(b"newer")
+            ignored.write_bytes(b"ignored")
+
+            older_mtime = 1_778_000_000
+            newer_mtime = older_mtime + 60
+            ignored_mtime = newer_mtime + 60
+            older.touch()
+            newer.touch()
+            ignored.touch()
+            import os
+
+            os.utime(older, (older_mtime, older_mtime))
+            os.utime(newer, (newer_mtime, newer_mtime))
+            os.utime(ignored, (ignored_mtime, ignored_mtime))
+
+            self.assertEqual(find_latest_screenshot([Path(first_root), Path(second_root)]), newer)
+
+    def test_returns_none_when_no_screenshot_exists(self):
+        with tempfile.TemporaryDirectory() as root:
+            self.assertIsNone(find_latest_screenshot([Path(root)]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_svg.py
+++ b/tests/python/test_svg.py
@@ -1,0 +1,72 @@
+import unittest
+import xml.etree.ElementTree as ET
+
+from geometrize_py.svg import render_svg
+
+
+class SvgTests(unittest.TestCase):
+    def test_render_svg_serializes_rectangle_shape(self):
+        svg = render_svg(
+            10,
+            20,
+            [
+                {
+                    "type": "rectangle",
+                    "color": {"r": 10, "g": 20, "b": 30, "a": 128},
+                    "data": {"x1": 1, "y1": 2, "x2": 5, "y2": 8},
+                }
+            ],
+        )
+
+        root = ET.fromstring(svg)
+        rect = root.find("{http://www.w3.org/2000/svg}rect")
+
+        self.assertEqual(root.attrib["width"], "10")
+        self.assertEqual(root.attrib["height"], "20")
+        self.assertIsNotNone(rect)
+        self.assertEqual(rect.attrib["id"], "0")
+        self.assertEqual(rect.attrib["fill"], "rgb(10,20,30)")
+        self.assertEqual(rect.attrib["fill-opacity"], "0.501961")
+
+    def test_render_svg_serializes_line_as_stroke(self):
+        svg = render_svg(
+            10,
+            20,
+            [
+                {
+                    "type": "line",
+                    "color": {"r": 1, "g": 2, "b": 3, "a": 255},
+                    "data": {"x1": 1, "y1": 2, "x2": 5, "y2": 8},
+                }
+            ],
+        )
+
+        root = ET.fromstring(svg)
+        line = root.find("{http://www.w3.org/2000/svg}line")
+
+        self.assertIsNotNone(line)
+        self.assertEqual(line.attrib["stroke"], "rgb(1,2,3)")
+        self.assertEqual(line.attrib["fill"], "none")
+
+    def test_render_svg_serializes_rotated_rectangle_as_polygon(self):
+        svg = render_svg(
+            10,
+            20,
+            [
+                {
+                    "type": "rotated_rectangle",
+                    "color": {"r": 1, "g": 2, "b": 3, "a": 255},
+                    "data": {"x1": 2, "y1": 2, "x2": 6, "y2": 4, "angle": 0},
+                }
+            ],
+        )
+
+        root = ET.fromstring(svg)
+        polygon = root.find("{http://www.w3.org/2000/svg}polygon")
+
+        self.assertIsNotNone(polygon)
+        self.assertEqual(polygon.attrib["points"], "2,2 6,2 6,4 2,4")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds a Python headless orchestration layer for Geometrize while keeping the existing C++ image approximation algorithm as the native core.

It includes:

- a `geometrize-py` CLI for dry runs, latest-screenshot discovery, single jobs, and batch manifests
- Python job manifest parsing and image IO helpers
- a pybind11/scikit-build native extension that drives the existing `lib/geometrize` `ImageRunner`
- PNG, JSON, and SVG export paths from Python
- focused Python tests and README workflow documentation

## Why

The goal is to make the headless and app-layer workflow lighter and easier to automate without rewriting the core approximation algorithm yet. This creates a practical Python surface for screenshot-to-shapes jobs and repeatable batch runs, while leaving the algorithmic port as a later, explicit step.

## Validation

- `C:\LocalRepos\geometrize\.venv\Scripts\python.exe -m pip install -e C:\LocalRepos\geometrize`
- `C:\LocalRepos\geometrize\.venv\Scripts\python.exe -m unittest discover -s C:\LocalRepos\geometrize\tests\python` (`33` tests passing)
- `C:\LocalRepos\geometrize\.venv\Scripts\python.exe -m compileall -q C:\LocalRepos\geometrize\python C:\LocalRepos\geometrize\tests\python`
- `git -C C:\LocalRepos\geometrize diff --check`

Draft because this is a sizable port path and may want maintainer review on package layout, CLI shape, and how much of the existing Qt app should eventually route through this Python layer.
